### PR TITLE
[UI] Create detail page of TodoList

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { HomePageSection } from "./_components/HomePageSection";
+import { HomePageSection } from "@/app/_components/HomePageSection";
 
 export default function Home() {
   return <HomePageSection />;

--- a/app/todos/[id]/_components/TodoDetailSection.tsx
+++ b/app/todos/[id]/_components/TodoDetailSection.tsx
@@ -1,0 +1,10 @@
+import styles from "@/app/todos/[id]/styles/todoDetailSection.module.css";
+
+export const TodoDetailSection = () => {
+  return (
+    <div className={styles.container}>
+      {/* This dummy title should be replaced later */}
+      <h3 className={styles.todoTitle}>Todo title</h3>
+    </div>
+  );
+};

--- a/app/todos/[id]/layout.tsx
+++ b/app/todos/[id]/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from "react";
+import styles from "@/app/todos/[id]/styles/layout.module.css";
+
+export default function TodoItemLayout({ children }: { children: ReactNode }) {
+  return <main className={styles.wrapper}>{children}</main>;
+}

--- a/app/todos/[id]/page.tsx
+++ b/app/todos/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { TodoDetailSection } from "./_components/TodoDetailSection";
+
+export default function TodoDetail() {
+  return <TodoDetailSection />;
+}

--- a/app/todos/[id]/styles/layout.module.css
+++ b/app/todos/[id]/styles/layout.module.css
@@ -1,0 +1,5 @@
+.wrapper {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+}

--- a/app/todos/[id]/styles/todoDetailSection.module.css
+++ b/app/todos/[id]/styles/todoDetailSection.module.css
@@ -1,0 +1,14 @@
+.container {
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 2rem;
+  padding-top: 2rem;
+}
+
+.todoTitle {
+  font-weight: 500;
+  font-size: 20px;
+}


### PR DESCRIPTION
## What I've done in this pull request

- Added `todos/[id]` directory for routing of todo detail page
- Added `page.tsx` and `layout.tsx` to `todos/[id]` directory 
- Added `TodoDetailPageSection` and `todoDetailPageSection.module.css`
- Applied minimum styles to `TodoDetailPageSection`