### PR TITLE
[Enhancement] Remove TodoId from Todo detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 株式会社H&Company コーディング課題
+# 株式会社 H&Company コーディング課題
 
-このリポジトリは 株式会社H＆Company のコーディング課題であり、Next.js 13 (App Router), TypeScript, プレーンな CSS を用いて作成した TODO リストアプリケーションです。
+このリポジトリは 株式会社 H＆Company のコーディング課題であり、Next.js 13 (App Router), TypeScript, プレーンな CSS を用いて作成した TODO リストアプリケーションです。
 
 ## インストール前提条件
 
@@ -66,6 +66,7 @@ app
 - プレーンな CSS によるスタイリングには CSS Modules を用いています。
 - Todo の新規作成、更新、削除に応じて Todo のデータを Global State だけでなく、`data.json`にも保存します。（`/api/todos`を用いて`data.json`を更新しています。）その為、ページをリロードしても Todo のデータはリセットされることなく表示されます。
 - 完了した Todo については、各 Todo の左端にあるチェックボックスにチェックを入れることで完了状態へ変更することができます。
+- GitHub Actions を導入し、デプロイメントのプロセスを自動化しています。
 
 ## スクリーンショット
 

--- a/app/todos/[id]/_components/TodoDetailSection.tsx
+++ b/app/todos/[id]/_components/TodoDetailSection.tsx
@@ -15,7 +15,7 @@ export const TodoDetailSection = () => {
 
   return (
     <div className={styles.container}>
-      <h2>Todo Detail - {correspondingTodo?.id}</h2>
+      <h2>Todo Detail</h2>
       <div className={styles.todoContentsSection}>
         <div className={styles.todoContent}>
           <h4 className={styles.contentTitle}>Todo title: </h4>


### PR DESCRIPTION
## What I've done in this pull request

- Removed `todoId` from Todo Detail Page

<img width="775" alt="スクリーンショット 2024-04-21 2 11 57" src="https://github.com/keento0809/h-company-coding-assignment/assets/65790344/e6ffc9fd-29e6-414c-b10f-e9309d44f2f8">
